### PR TITLE
Add dim_aux model with surrogate key

### DIFF
--- a/dbt_jobads_project/models/dim/dim_aux.sql
+++ b/dbt_jobads_project/models/dim/dim_aux.sql
@@ -1,0 +1,8 @@
+with dim_aux as (select * from {{ ref('src_aux') }})
+
+select
+    {{ dbt_utils.generate_surrogate_key(['driving_license_required', 'own_car_required', 'experience_required']) }} as aux_id,
+    driving_license_required,
+    own_car_required,
+    experience_required
+from dim_aux


### PR DESCRIPTION
Added a new dimensional model - dim-aux - which contains a surrogate key to ensure a uniqe and consistent row identification. 