### PR TITLE
Add dim_occupation model with surrogate key

### DIFF
--- a/dbt_jobads_project/models/dim/dim_occupation.sql
+++ b/dbt_jobads_project/models/dim/dim_occupation.sql
@@ -1,0 +1,16 @@
+-- Create a temporary table (CTE) to store the occupation data from the source table
+with dim_occupation as (
+    select * from {{ ref('src_occupation') }})
+
+-- Build the final occupation dimension table by selecting distinct values from the temporary table
+-- and generating a surrogate key for the occupation
+    select
+    {{ dbt_utils.generate_surrogate_key(['occupation']) }} as occupation_id,
+    occupation,
+    max(occupation_group) as occupation_group, -- get a representative group for each occupation
+    max(occupation_field) as occupation_field -- get a representative field for each occupation
+from dim_occupation
+group by occupation -- group by occupation to ensure unique values
+
+
+


### PR DESCRIPTION
Added a new dimensional model, dim_occupation, built from src_occupation. The model includes:

- A surrogate key (occupation_id) generated from the occupation field

- Distinct occupations grouped to ensure uniqueness

- Representative values for occupation_group and occupation_field using max()