### PR TITLE
Improve src_occupation model with null handling

### DIFF
--- a/dbt_jobads_project/models/src/src_occupation.sql
+++ b/dbt_jobads_project/models/src/src_occupation.sql
@@ -1,18 +1,22 @@
+-- This model is used to extract the occupation data from the job ads source table.
 with stg_job_ads as (select * from {{ source('job_ads', 'stg_ads') }}) 
       
-    
-    select distinct
-        occupation__concept_id as occupation_id,
-        occupation__label as occupation,
-        occupation__legacy_ams_taxonomy_id,
-        occupation_group__concept_id as occupation_group_id,
-        occupation_group__label as occupation_group,
-        occupation_group__legacy_ams_taxonomy_id,
-        occupation_field__concept_id as occupation_field_id,
-        occupation_field__label as occupation_field,
-        occupation_field__legacy_ams_taxonomy_id
+    -- Coalesce is used to handle null values and replace them with 'Ingen data'.
+    -- This is useful to ensure that the final output does not contain any null values.
+   select distinct
+    occupation__concept_id as occupation_id,
+    coalesce(occupation__label, 'Ingen data') as occupation,
+    coalesce(occupation__legacy_ams_taxonomy_id, 'Ingen data') as occupation_legacy_id,
 
-    from stg_job_ads
+    coalesce(occupation_group__concept_id, 'Ingen data') as occupation_group_id,
+    coalesce(occupation_group__label, 'Ingen data') as occupation_group,
+    coalesce(occupation_group__legacy_ams_taxonomy_id, 'Ingen data') as occupation_group_legacy_id,
+
+    coalesce(occupation_field__concept_id, 'Ingen data') as occupation_field_id,
+    coalesce(occupation_field__label, 'Ingen data') as occupation_field,
+    coalesce(occupation_field__legacy_ams_taxonomy_id, 'Ingen data') as occupation_field_legacy_id
+
+from stg_job_ads
 
 
    


### PR DESCRIPTION
- Added COALESCE function to src_occupation to replace NULL values with 'Ingen data'.
- Ensures more robust and readable, output when occupation fields are missing.