### PR TITLE
Update fct_job_ads and marts structure for occupation modeling

### DIFF
--- a/dbt_jobads_project/models/fct/fct_job_ads.sql
+++ b/dbt_jobads_project/models/fct/fct_job_ads.sql
@@ -7,10 +7,10 @@ dim_aux AS (
 )
 
 SELECT
-    {{ dbt_utils.generate_surrogate_key(['occupation__label']) }} AS occupation_id,
-    {{ dbt_utils.generate_surrogate_key(['id']) }} AS job_details_id,
-    {{ dbt_utils.generate_surrogate_key(['employer__workplace', 'workplace_address__municipality']) }} AS employer_id,
-    dim_aux.auxiliary_attributes_id
+    {{ dbt_utils.generate_surrogate_key(['job_ads.occupation__label']) }} AS occupation_id,
+    {{ dbt_utils.generate_surrogate_key(['job_ads.id']) }} AS job_details_id,
+    {{ dbt_utils.generate_surrogate_key(['job_ads.employer__workplace', 'job_ads.workplace_address__municipality']) }} AS employer_id,
+    dim_aux.auxiliary_attributes_id,
     job_ads.vacancies,
     job_ads.relevance,
     job_ads.application_deadline

--- a/dbt_jobads_project/models/marts/marts_occupation_social.sql
+++ b/dbt_jobads_project/models/marts/marts_occupation_social.sql
@@ -1,0 +1,25 @@
+WITH 
+    fct_job_ads as (select * from {{ ref('fct_job_ads') }}),
+    dim_job_details as (select * from {{ ref('dim_job_details') }}),
+    dim_occupation as (select * from {{ ref('dim_occupation') }})
+
+SELECT
+    jd.headline,
+    f.vacancies,
+    f.relevance,
+    o.occupation,
+    o.occupation_group,
+    o.occupation_field,
+    f.application_deadline,
+    jd.description,
+    jd.duration,
+    jd.salary_type,
+    
+FROM fct_job_ads f
+LEFT JOIN dim_job_details jd ON f.job_details_id = jd.job_details_id
+LEFT JOIN dim_occupation o ON f.occupation_id = o.occupation_id
+WHERE o.occupation_field = 'Yrken med social inriktning'
+
+
+
+

--- a/dbt_jobads_project/models/marts/marts_occupation_social.sql
+++ b/dbt_jobads_project/models/marts/marts_occupation_social.sql
@@ -15,11 +15,9 @@ SELECT
     jd.duration,
     jd.salary_type,
     
+    
 FROM fct_job_ads f
 LEFT JOIN dim_job_details jd ON f.job_details_id = jd.job_details_id
 LEFT JOIN dim_occupation o ON f.occupation_id = o.occupation_id
+
 WHERE o.occupation_field = 'Yrken med social inriktning'
-
-
-
-


### PR DESCRIPTION
- Modified fct_job_ads: added 'job_ads' prefix to all columns in the surrogate key to resolve dbt run issues.
- Added a new marts model for the occupation group 'Yrken med social inriktning'.
- Removed test_marts.sql as the 'marts' folder is now visible to all group members.