### PR TITLE
Remove 'job_ads' prefix from fct model

### DIFF
--- a/dbt_jobads_project/models/fct/fct_job_ads.sql
+++ b/dbt_jobads_project/models/fct/fct_job_ads.sql
@@ -11,9 +11,9 @@ SELECT
     {{ dbt_utils.generate_surrogate_key(['job_ads.id']) }} AS job_details_id,
     {{ dbt_utils.generate_surrogate_key(['job_ads.employer__workplace', 'job_ads.workplace_address__municipality']) }} AS employer_id,
     dim_aux.auxiliary_attributes_id,
-    job_ads.vacancies,
-    job_ads.relevance,
-    job_ads.application_deadline
+    vacancies,
+    relevance,
+    application_deadline
 FROM job_ads
 LEFT JOIN dim_aux
     ON job_ads.driving_license_required = dim_aux.driving_license_required

--- a/dbt_jobads_project/package-lock.yml
+++ b/dbt_jobads_project/package-lock.yml
@@ -1,4 +1,4 @@
 packages:
-- package: dbt-labs/dbt_utils
-  version: 1.3.0
-sha1_hash: e60f3271d7a9f853b7ff6316d14feb1341ef78ea
+  - package: dbt-labs/dbt_utils
+    version: 1.3.0
+sha1_hash: 226ae69cdfbc9367e2aa2c472b01f99dbce11de0


### PR DESCRIPTION
In a previous commit, I added the job_ads table to the fct model to make dbt run work. 
I’ve now tested removing the job_ads prefix from the code and ran dbt run successfully. 

This PR pushes the updated code without the job_ads prefix in the fct-model.