### PR TITLE
Adding dashboard_app and jobads_dashboard.py to test fetching data fr…

### DIFF
--- a/dashboard_app/jobads_dashboard.py
+++ b/dashboard_app/jobads_dashboard.py
@@ -1,0 +1,25 @@
+import streamlit as st
+import duckdb
+import pandas as pd
+from pathlib import Path
+
+
+# Set up the page configuration
+st.set_page_config(page_title="HR Analytics Dashboard", layout="wide")
+st.title("HR Analytics Dashboard")
+
+
+# Connect to DuckDB to get data from the data warehouse
+conn = duckdb.connect(database="../jobads_data_warehouse.duckdb", read_only=True)
+
+query = "SELECT * FROM marts.marts_occupation_social LIMIT 10"
+df = conn.execute(query).fetchdf()
+
+# Close the connection
+conn.close()
+
+# Display the DataFrame in Streamlit
+st.subheader("Visar jobbannonser för området yrken med social inriktning")
+st.dataframe(df)
+st.markdown("Här visas data hämtat från duckdb.")
+


### PR DESCRIPTION
This pull request adds a new Streamlit dashboard under dashboard_app/jobads_dashboard.py to test fetching data from the marts_occupation_social table in the data warehouse.

The purpose is to verify that job ad data can be accessed and prepared for future visualization.

No data transformation or filtering logic is included yet – this will follow in a later PR.