### PR TITLE
Renamed the mart-dimension,  and added a mart for default visualization for all occupations

### DIFF
--- a/dashboard_app/jobads_dashboard.py
+++ b/dashboard_app/jobads_dashboard.py
@@ -13,9 +13,10 @@ st.title("HR Analytics Dashboard")
 
 # Conncetion between occupation field and marts
 occupation_to_mart = {
-    "Yrken med social inriktning": "marts.marts_occupation_social",
-    "Yrken med teknisk inriktning": "marts.marts_it_jobs",
-    "Chefer och verksamhetsledare" : "marts.marts_leadership_jobs"
+    "Samtliga yrkesområden": "mart.mart_all_jobs",
+    "Yrken med social inriktning": "mart.mart_occupation_social",
+    "Yrken med teknisk inriktning": "mart.mart_it_jobs",
+    "Chefer och verksamhetsledare" : "mart.mart_leadership_jobs"
 }
 
 # User input for occupation field


### PR DESCRIPTION
Renamed the mart-dimension folder and files, from marts to mart, for consistency and clarity.

Added a new sql-ile: mart_all_jobs.sql. This enables the Streamlit dashboard to display all occupations by default,. 