### PR TITLE
Updates in dashboards and models to eliminate duplicates. 

### DIFF
--- a/dashboard_app/pages/Yrken_med_social_inriktning.py
+++ b/dashboard_app/pages/Yrken_med_social_inriktning.py
@@ -1,13 +1,55 @@
 import streamlit as st
 from utils import DataBase_Connection
+import pandas as pd
+import matplotlib.pyplot as plt
+import plotly.express as px
 
+# ======= PAGE SETUP ========
 
 st.set_page_config(page_title="HR Analytics Dashboard", layout="wide")
 st.title("Yrkesområden med social inriktning")
 
-st.markdown("Enligt Arbetsförmedlingen är yrken med social inriktning de som handlar om att hjälpa och stödja människor")
-st.sidebar.header("Yrkesområden")
+st.markdown("Visar tillgängliga arbeten inom yrkesområden med social inriktning. ")
+st.sidebar.success("Viktig info")
 
 progress_bar = st.sidebar.progress(0)
 status_text = st.sidebar.empty()
 
+# ======== DATA LOADING ========
+
+
+# with DataBase_Connection() as conn:
+#      df_top10 = conn.execute("SELECT * FROM mart_top_ten_social_occ").fetchdf()
+    
+with DataBase_Connection() as conn:
+    df = conn.execute("SELECT * FROM mart.mart_all_jobs").fetchdf()
+    df = df[df["occupation_field"] == "Yrken med social inriktning"]
+     
+
+# ======== SHOW DATA ========
+column1, column2, column3, column4 = st.columns(4)
+
+column1.metric("Antal jobbannonser", df.shape[0])
+column2.metric("Antal unika yrkestitlar", df['occupation'].nunique())
+column3.metric("Antal unika arbetsgivare", df['employer_name'].nunique())
+column4.metric("Antal unika kommuner", df['workplace_region'].nunique())
+
+column4, column5 = st.columns(2)
+
+# ======== Pagination Logic ======== INTE EGEN KOD!!!
+st.markdown("### Annonser")
+
+rows_per_page = 50  # Visa 50 rader per sida
+total_rows = len(df)
+total_pages = (total_rows - 1) // rows_per_page + 1
+
+# Välj sida i en selectbox eller number_input
+page = st.number_input("Sida", min_value=1, max_value=total_pages, value=1, step=1)
+
+start_idx = (page - 1) * rows_per_page
+end_idx = min(start_idx + rows_per_page, total_rows)
+
+st.markdown(f"Visar rader **{start_idx + 1}–{end_idx}** av totalt **{total_rows}**.")
+
+# Visa bara den aktuella sidan
+st.dataframe(df.iloc[start_idx:end_idx], use_container_width=True)

--- a/dbt_jobads_project/models/dim/dim_aux.sql
+++ b/dbt_jobads_project/models/dim/dim_aux.sql
@@ -1,4 +1,10 @@
-with dim_aux as (select * from {{ ref('src_aux') }})
+with dim_aux as (
+    select distinct
+    driving_license_required,
+    own_car_required,
+    experience_required
+    from {{ ref('src_aux') }}
+    )
 
 select
     {{ dbt_utils.generate_surrogate_key(['driving_license_required', 'own_car_required', 'experience_required']) }} as auxiliary_attributes_id,

--- a/dbt_jobads_project/models/mart/mart_all_jobs.sql
+++ b/dbt_jobads_project/models/mart/mart_all_jobs.sql
@@ -1,13 +1,53 @@
+WITH  
+    fct_job_ads AS (SELECT * FROM {{ ref('fct_job_ads') }}),
+    dim_job_details AS (SELECT * FROM {{ ref('dim_job_details') }}),
+    dim_occupation AS (SELECT * FROM {{ ref('dim_occupation') }}),
+    dim_employer AS (SELECT * FROM {{ ref('dim_employer') }}),
+    dim_aux AS (SELECT * FROM {{ ref('dim_aux') }}),
 
-select *, 'Yrken med social inriktning' as occupation_field
-from {{ ref('mart_occupation_social')}}
+    joined AS (
+        SELECT
+            f.job_details_id AS job_id,
+            jd.headline,
+            f.vacancies,
+            f.relevance,
+            o.occupation,
+            o.occupation_group,
+            o.occupation_field,
+            f.application_deadline,
+            jd.description,
+            jd.duration,
+            jd.salary_type,
+            e.employer_name,
+            e.employer_workplace,
+            e.workplace_region,
+            jd.employment_type,
+            jd.scope_of_work_min,
+            jd.scope_of_work_max,
+            a.driving_license_required,
+            a.own_car_required,
+            a.experience_required
+        FROM fct_job_ads f
+        LEFT JOIN dim_job_details jd ON f.job_details_id = jd.job_details_id
+        LEFT JOIN dim_occupation o ON f.occupation_id = o.occupation_id
+        LEFT JOIN dim_employer e ON f.employer_id = e.employer_id
+        LEFT JOIN dim_aux a ON f.auxiliary_attributes_id = a.auxiliary_attributes_id
+       WHERE o.occupation_field IN (
+      'Yrken med social inriktning',
+      'Yrken med teknisk inriktning',
+      'Chefer och verksamhetsledare'
+      )
+    ),
 
-union all
+    ranked AS (
+        SELECT *,
+               ROW_NUMBER() OVER (
+                   PARTITION BY job_id
+                   ORDER BY application_deadline DESC
+               ) AS rn
+        FROM joined
+    )
 
-select *, 'Yrken med teknisk inriktning' as occupation_field
-from {{ ref('mart_it_jobs')}}
-
-union all
-
-select *,  'Chefer och verksamhetsledare' as occupation_field
-from {{ ref('mart_leadership_jobs')}}
+SELECT *
+FROM ranked
+WHERE rn = 1

--- a/dbt_jobads_project/models/mart/mart_it_jobs.sql
+++ b/dbt_jobads_project/models/mart/mart_it_jobs.sql
@@ -3,31 +3,46 @@ WITH
     dim_job_details AS (SELECT * FROM {{ ref('dim_job_details') }}),
     dim_occupation AS (SELECT * FROM {{ ref('dim_occupation') }}),
     dim_employer AS (SELECT * FROM {{ ref('dim_employer') }}),
-    dim_aux AS (SELECT * FROM {{ ref('dim_aux') }})
+    dim_aux AS (SELECT * FROM {{ ref('dim_aux') }}),
 
-SELECT
-   jd.headline,
-    f.vacancies,
-    f.relevance,
-    o.occupation,
-    o.occupation_group,
-    o.occupation_field,
-    f.application_deadline,
-    jd.description,
-    jd.duration,
-    jd.salary_type,
-    e.employer_name,
-    e.employer_workplace,
-    e.workplace_region,
-    jd.employment_type,
-    jd.scope_of_work_min,
-    jd.scope_of_work_max,
-    a.driving_license_required,
-    a.own_car_required,
-    a.experience_required
-FROM fct_job_ads f
-LEFT JOIN dim_job_details jd ON f.job_details_id = jd.job_details_id
-LEFT JOIN dim_occupation o ON f.occupation_id = o.occupation_id
-LEFT JOIN dim_employer e ON f.employer_id = e.employer_id
-LEFT JOIN dim_aux a ON f.auxiliary_attributes_id = a.auxiliary_attributes_id
-WHERE o.occupation_field = 'Yrken med teknisk inriktning'
+    joined AS (
+        SELECT
+            f.job_details_id AS job_id,
+            jd.headline,
+            f.vacancies,
+            f.relevance,
+            o.occupation,
+            o.occupation_group,
+            o.occupation_field,
+            f.application_deadline,
+            jd.description,
+            jd.duration,
+            jd.salary_type,
+            e.employer_name,
+            e.employer_workplace,
+            e.workplace_region,
+            jd.employment_type,
+            jd.scope_of_work_min,
+            jd.scope_of_work_max,
+            a.driving_license_required,
+            a.own_car_required,
+            a.experience_required
+        FROM fct_job_ads f
+        LEFT JOIN dim_job_details jd ON f.job_details_id = jd.job_details_id
+        LEFT JOIN dim_occupation o ON f.occupation_id = o.occupation_id
+        LEFT JOIN dim_employer e ON f.employer_id = e.employer_id
+        LEFT JOIN dim_aux a ON f.auxiliary_attributes_id = a.auxiliary_attributes_id
+    WHERE o.occupation_field = 'Yrken med teknisk inriktning'
+    ),
+
+    ranked AS (
+        SELECT *,
+            ROW_NUMBER() OVER (
+                PARTITION BY job_id
+                ORDER BY application_deadline DESC
+            ) AS rn
+        FROM joined
+    )
+SELECT *
+FROM ranked
+WHERE rn = 1

--- a/dbt_jobads_project/models/mart/mart_leadership_jobs.sql
+++ b/dbt_jobads_project/models/mart/mart_leadership_jobs.sql
@@ -3,31 +3,46 @@ WITH
     dim_job_details as (select * from {{ ref('dim_job_details') }}),
     dim_occupation as (select * from {{ ref('dim_occupation') }}),
     dim_employer as (select * from {{ ref('dim_employer') }}),
-    dim_aux AS (SELECT * FROM {{ ref('dim_aux') }})
-    
-SELECT
-    jd.headline,
-    f.vacancies,
-    f.relevance,
-    o.occupation,
-    o.occupation_group,
-    o.occupation_field,
-    f.application_deadline,
-    jd.description,
-    jd.duration,
-    jd.salary_type,
-    e.employer_name,
-    e.employer_workplace,
-    e.workplace_region,
-    jd.employment_type,
-    jd.scope_of_work_min,
-    jd.scope_of_work_max,
-    a.driving_license_required,
-    a.own_car_required,
-    a.experience_required
-FROM fct_job_ads f
-LEFT JOIN dim_job_details jd ON f.job_details_id = jd.job_details_id
-LEFT JOIN dim_occupation o ON f.occupation_id = o.occupation_id
-LEFT JOIN dim_employer e ON f.employer_id = e.employer_id
-LEFT JOIN dim_aux a ON f.auxiliary_attributes_id = a.auxiliary_attributes_id
-WHERE o.occupation_field = 'Chefer och verksamhetsledare'
+    dim_aux AS (SELECT * FROM {{ ref('dim_aux') }}),
+
+    joined AS (
+        SELECT
+            f.job_details_id AS job_id,
+            jd.headline,
+            f.vacancies,
+            f.relevance,
+            o.occupation,
+            o.occupation_group,
+            o.occupation_field,
+            f.application_deadline,
+            jd.description,
+            jd.duration,
+            jd.salary_type,
+            e.employer_name,
+            e.employer_workplace,
+            e.workplace_region,
+            jd.employment_type,
+            jd.scope_of_work_min,
+            jd.scope_of_work_max,
+            a.driving_license_required,
+            a.own_car_required,
+            a.experience_required
+        FROM fct_job_ads f
+        LEFT JOIN dim_job_details jd ON f.job_details_id = jd.job_details_id
+        LEFT JOIN dim_occupation o ON f.occupation_id = o.occupation_id
+        LEFT JOIN dim_employer e ON f.employer_id = e.employer_id
+        LEFT JOIN dim_aux a ON f.auxiliary_attributes_id = a.auxiliary_attributes_id
+    WHERE o.occupation_field = 'Chefer och verksamhetsledare'
+    ),   
+    ranked AS (
+        SELECT *,
+            ROW_NUMBER() OVER (
+                PARTITION BY job_id
+                ORDER BY application_deadline DESC
+            ) AS rn
+        FROM joined
+    )
+
+SELECT *
+FROM ranked
+WHERE rn = 1

--- a/dbt_jobads_project/models/mart/mart_occupation_social.sql
+++ b/dbt_jobads_project/models/mart/mart_occupation_social.sql
@@ -1,33 +1,50 @@
-WITH 
-    fct_job_ads as (select * from {{ ref('fct_job_ads') }}),
-    dim_job_details as (select * from {{ ref('dim_job_details') }}),
-    dim_occupation as (select * from {{ ref('dim_occupation') }}),
-    dim_employer as (select * from {{ ref('dim_employer') }}),
-    dim_aux as (select * from {{ ref('dim_aux') }})  
+WITH  
+    fct_job_ads AS (SELECT * FROM {{ ref('fct_job_ads') }}),
+    dim_job_details AS (SELECT * FROM {{ ref('dim_job_details') }}),
+    dim_occupation AS (SELECT * FROM {{ ref('dim_occupation') }}),
+    dim_employer AS (SELECT * FROM {{ ref('dim_employer') }}),
+    dim_aux AS (SELECT * FROM {{ ref('dim_aux') }}),
 
-SELECT
-    jd.headline,
-    f.vacancies,
-    f.relevance,
-    o.occupation,
-    o.occupation_group,
-    o.occupation_field,
-    f.application_deadline,
-    jd.description,
-    jd.duration,
-    jd.salary_type,
-    e.employer_name,
-    e.employer_workplace,
-    e.workplace_region,
-    jd.employment_type,
-    jd.scope_of_work_min,
-    jd.scope_of_work_max,
-    a.driving_license_required,
-    a.own_car_required,
-    a.experience_required
-FROM fct_job_ads f
-LEFT JOIN dim_job_details jd ON f.job_details_id = jd.job_details_id
-LEFT JOIN dim_occupation o ON f.occupation_id = o.occupation_id
-LEFT JOIN dim_employer e ON f.employer_id = e.employer_id
-LEFT JOIN dim_aux a ON f.auxiliary_attributes_id = a.auxiliary_attributes_id
-WHERE o.occupation_field = 'Yrken med social inriktning'
+    joined AS (
+        SELECT
+            f.job_details_id AS job_id,
+            jd.headline,
+            f.vacancies,
+            f.relevance,
+            o.occupation,
+            o.occupation_group,
+            o.occupation_field,
+            f.application_deadline,
+            jd.description,
+            jd.duration,
+            jd.salary_type,
+            e.employer_name,
+            e.employer_workplace,
+            e.workplace_region,
+            jd.employment_type,
+            jd.scope_of_work_min,
+            jd.scope_of_work_max,
+            a.driving_license_required,
+            a.own_car_required,
+            a.experience_required
+        FROM fct_job_ads f
+        LEFT JOIN dim_job_details jd ON f.job_details_id = jd.job_details_id
+        LEFT JOIN dim_occupation o ON f.occupation_id = o.occupation_id
+        LEFT JOIN dim_employer e ON f.employer_id = e.employer_id
+        LEFT JOIN dim_aux a ON f.auxiliary_attributes_id = a.auxiliary_attributes_id
+        WHERE o.occupation_field = 'Yrken med social inriktning'
+    ),
+
+    ranked AS (
+        SELECT *,
+               ROW_NUMBER() OVER (
+                   PARTITION BY job_id
+                   ORDER BY application_deadline DESC
+               ) AS rn
+        FROM joined
+    )
+
+SELECT *
+FROM ranked
+WHERE rn = 1
+

--- a/dbt_jobads_project/models/mart/mart_top_ten_social_occ.sql
+++ b/dbt_jobads_project/models/mart/mart_top_ten_social_occ.sql
@@ -1,0 +1,16 @@
+
+with
+   dim_occupation as (select * from {{ ref('dim_occupation') }}),
+   fct_job_ads as (select * from {{ ref('fct_job_ads') }})
+
+select
+    any_value(fct.job_details_id) as job_id,
+    occ.occupation_field,
+    occ.occupation,
+    count(*) as antal_annons
+from refined.fct_job_ads fct
+left join refined.dim_occupation occ
+    on fct.occupation_id = occ.occupation_id
+where occ.occupation_field = 'Yrken med social inriktning'
+group by occ.occupation_field, occ.occupation
+order by antal_annons desc

--- a/dbt_jobads_project/models/src/src_job_ads.sql
+++ b/dbt_jobads_project/models/src/src_job_ads.sql
@@ -1,17 +1,26 @@
 
--- Code from lesson
-with stg_job_ads as (select * from {{ source('job_ads', 'stg_ads') }})
 
-select
+
+WITH stg_job_ads AS (
+    SELECT *,
+           ROW_NUMBER() OVER (
+               PARTITION BY id 
+               ORDER BY application_deadline DESC
+           ) AS rn
+    FROM {{ source('job_ads', 'stg_ads') }}
+)
+
+SELECT
     id,
     occupation__label,    
-    number_of_vacancies as vacancies,
+    number_of_vacancies AS vacancies,
     relevance,
     application_deadline,
     driving_license_required,
-    access_to_own_car as own_car_required,
+    access_to_own_car AS own_car_required,
     experience_required,
     employer__name,
     employer__workplace,
     workplace_address__municipality 
-from stg_job_ads
+FROM stg_job_ads
+WHERE rn = 1


### PR DESCRIPTION

This pull request includes the following updates:
- Added an unique id for each mart-model to be able to track why there were dubplicates in the duckdb and streamlit app. 
- Added a 'select distinct' in the dim aux-model to eliminate duplicates
- Used ROW_NUMBER() to filter out duplicate job ads caused by joins, keeping only the latest record per job ID (this with help from chat GPT, since nothing else I tried worked out). 
- Also added new model, mart_top_ten_social, to try analyzing the social occupation field. 

Changes in the jobads_dashboard.py are intentionally excluded to avoid conflicts with work by teammate. 