### PR TITLE
Added publication date to the src, dim and mart models

### DIFF
--- a/dbt_jobads_project/models/dim/dim_job_details.sql
+++ b/dbt_jobads_project/models/dim/dim_job_details.sql
@@ -3,6 +3,7 @@ WITH job_details AS (SELECT * FROM {{ ref('src_job_details') }})
 SELECT
     {{ dbt_utils.generate_surrogate_key(['id']) }} AS job_details_id,
     COALESCE (headline, 'Ingen data') AS headline,
+    CAST(publication_date AS DATE) AS publication_date,
     COALESCE (description, 'Ingen data') AS description,
     COALESCE (description_html_formatted, 'Ingen data') AS description_html_formatted,
     COALESCE (employment_type, 'Ingen data') AS employment_type,

--- a/dbt_jobads_project/models/mart/mart_all_jobs.sql
+++ b/dbt_jobads_project/models/mart/mart_all_jobs.sql
@@ -7,7 +7,7 @@ WITH
 
     joined AS (
         SELECT
-            f.job_details_id AS job_id,
+            CAST(jd.publication_date AS DATE) AS publication_date,
             jd.headline,
             f.vacancies,
             f.relevance,
@@ -26,7 +26,8 @@ WITH
             jd.scope_of_work_max,
             a.driving_license_required,
             a.own_car_required,
-            a.experience_required
+            a.experience_required,
+            f.job_details_id AS job_id
         FROM fct_job_ads f
         LEFT JOIN dim_job_details jd ON f.job_details_id = jd.job_details_id
         LEFT JOIN dim_occupation o ON f.occupation_id = o.occupation_id

--- a/dbt_jobads_project/models/mart/mart_it_jobs.sql
+++ b/dbt_jobads_project/models/mart/mart_it_jobs.sql
@@ -7,6 +7,7 @@ WITH
 
     joined AS (
         SELECT
+            CAST(jd.publication_date AS DATE) AS publication_date,
             f.job_details_id AS job_id,
             jd.headline,
             f.vacancies,

--- a/dbt_jobads_project/models/mart/mart_leadership_jobs.sql
+++ b/dbt_jobads_project/models/mart/mart_leadership_jobs.sql
@@ -7,6 +7,7 @@ WITH
 
     joined AS (
         SELECT
+            CAST(jd.publication_date AS DATE) AS publication_date,
             f.job_details_id AS job_id,
             jd.headline,
             f.vacancies,

--- a/dbt_jobads_project/models/mart/mart_occupation_social.sql
+++ b/dbt_jobads_project/models/mart/mart_occupation_social.sql
@@ -6,13 +6,11 @@ WITH
     dim_aux AS (SELECT * FROM {{ ref('dim_aux') }}),
 
     joined AS (
-        SELECT
-            f.job_details_id AS job_id,
+        SELECT           
+            CAST(jd.publication_date AS DATE) AS publication_date,
             jd.headline,
-            f.vacancies,
-            f.relevance,
             o.occupation,
-            o.occupation_group,
+            o.occupation_group, 
             o.occupation_field,
             f.application_deadline,
             jd.description,
@@ -21,12 +19,16 @@ WITH
             e.employer_name,
             e.employer_workplace,
             e.workplace_region,
+            f.vacancies,
             jd.employment_type,
             jd.scope_of_work_min,
             jd.scope_of_work_max,
             a.driving_license_required,
             a.own_car_required,
-            a.experience_required
+            a.experience_required,
+            f.job_details_id AS job_id,
+            f.relevance,
+
         FROM fct_job_ads f
         LEFT JOIN dim_job_details jd ON f.job_details_id = jd.job_details_id
         LEFT JOIN dim_occupation o ON f.occupation_id = o.occupation_id

--- a/dbt_jobads_project/models/src/src_job_ads.sql
+++ b/dbt_jobads_project/models/src/src_job_ads.sql
@@ -12,7 +12,8 @@ WITH stg_job_ads AS (
 
 SELECT
     id,
-    occupation__label,    
+    occupation__label,
+    publication_date,  
     number_of_vacancies AS vacancies,
     relevance,
     application_deadline,

--- a/dbt_jobads_project/models/src/src_job_details.sql
+++ b/dbt_jobads_project/models/src/src_job_details.sql
@@ -3,6 +3,7 @@ WITH stg_job_ads AS (SELECT * FROM {{ source('job_ads', 'stg_ads') }})
 SELECT
     id,
     headline,
+    publication_date,
     description__text AS description,
     description__text_formatted AS description_html_formatted,
     employment_type__label AS employment_type,


### PR DESCRIPTION

Added publication_date in src_job_ads, src_job_detail, and the dim_job_details since publication_date was missing, and it's hard to make any trend-plots without date.

Changes in the mart-models to view the publication_date in Streamlit dashboard. 